### PR TITLE
The smart quotes that were used in the readme file caused

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ python-ach
     :target: https://travis-ci.org/travishathaway/python-ach
 
 ACH file generator module for python. So far, this has been tested with
-“PPD” and “CCD” batches with addenda records.
+"PPD" and "CCD" batches with addenda records.
 
 Example
 =======


### PR DESCRIPTION
* I changed the smart quotes to regular quotes since the quotes prevented some environments from installing this package via git.
* essentially, the setup.py file reads the README.md file when `pip install` is run.
* because we don't handle the UTF encoding in the open, the pip install seems to fail in some linuxes and windows.