### PR TITLE
Add functionality so that if one entry breaks during a batch, it will…

### DIFF
--- a/ach/builder.py
+++ b/ach/builder.py
@@ -83,28 +83,30 @@ class AchFile(object):
         entry_counter = 1
 
         for record in batch_entries:
+            try:
+                entry = EntryDetail(
+                    std_ent_cls_code=std_ent_cls_code,
+                    id_number=record.get('id_number', ''),
+                )
 
-            entry = EntryDetail(
-                std_ent_cls_code=std_ent_cls_code,
-                id_number=record.get('id_number', ''),
-            )
+                entry.transaction_code = record.get('type')
+                entry.recv_dfi_id = record.get('routing_number')
 
-            entry.transaction_code = record.get('type')
-            entry.recv_dfi_id = record.get('routing_number')
+                if len(record['routing_number']) < 9:
+                    entry.calc_check_digit()
+                else:
+                    entry.check_digit = record['routing_number'][8]
 
-            if len(record['routing_number']) < 9:
-                entry.calc_check_digit()
-            else:
-                entry.check_digit = record['routing_number'][8]
+                entry.dfi_acnt_num = record['account_number']
+                entry.amount = int(round(float(record['amount']) * 100))
+                entry.ind_name = record['name'].upper()[:22]
+                entry.trace_num = self.settings['immediate_dest'][:8] \
+                    + entry.validate_numeric_field(entry_counter, 7)
 
-            entry.dfi_acnt_num = record['account_number']
-            entry.amount = int(round(float(record['amount']) * 100))
-            entry.ind_name = record['name'].upper()[:22]
-            entry.trace_num = self.settings['immediate_dest'][:8] \
-                + entry.validate_numeric_field(entry_counter, 7)
-
-            entries.append((entry, record.get('addenda', [])))
-            entry_counter += 1
+                entries.append((entry, record.get('addenda', [])))
+                entry_counter += 1
+            except:
+                raise Exception('AHH')
 
         self.batches.append(FileBatch(batch_header, entries))
         self.set_control()

--- a/ach/data_types.py
+++ b/ach/data_types.py
@@ -62,10 +62,7 @@ class Ach(object):
         """
         str_length = str(length)
 
-        match = re.match(
-            r'([\w\s^!_@#$%&,*:./+\-]{1,' + str_length + '})',
-            field,
-        )
+        match = re.match(r'([\w,\s]{1,' + str_length + '})', field)
 
         if match:
             if len(match.group(1)) < length:

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ from distutils.core import setup
 setup(
     name='carta-ach',
     author='Carta, Inc.',
-    author_email='jared.hobbs@carta.com',
-    version='0.4.5',
+    author_email='james.uejio@carta.com',
+    version='0.4.6',
     packages=[
         'ach',
     ],


### PR DESCRIPTION
… not crash the entire batch

The issue happens when one entry fails so the entire batch fails. Instead we need to handle this better.